### PR TITLE
Fixing issue #5 - `stem_words` example takes character vector, not da…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Description: Package contains a collection of functions that can be used to
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Imports: 
     checkmate,
     dplyr (>= 1.1.4),

--- a/R/stem_words.R
+++ b/R/stem_words.R
@@ -11,10 +11,10 @@
 #' @export
 #'
 #' @examplesIf interactive()
-#' df <- data.frame(
-#'   id = c(1, 2, 3, 4), word = c("win", "winning", "winner", NA)
-#' )
-#' stem_words(df, word)
+#'
+#' words <- c("win", "winning", "winner", NA)
+#'
+#' stem_words(words)
 #'
 stem_words <- function(x, exceptions = NULL) {
   assert_character(x)

--- a/man/stem_words.Rd
+++ b/man/stem_words.Rd
@@ -21,9 +21,9 @@ algorithm.
 }
 \examples{
 \dontshow{if (interactive()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
-df <- data.frame(
-  id = c(1, 2, 3, 4), word = c("win", "winning", "winner", NA)
-)
-stem_words(df, word)
+
+words <- c("win", "winning", "winner", NA)
+
+stem_words(words)
 \dontshow{\}) # examplesIf}
 }


### PR DESCRIPTION
…ta.frame.